### PR TITLE
Open target files write-only and loosen their permissions

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -586,7 +586,7 @@ int make_bsdiff_delta(char *old_filename, char *new_filename, char *delta_filena
 		memset(&small_header, 0, sizeof(struct header_v21));
 		memcpy(&small_header.magic, BSDIFF_HDR_FULLDL, 8);
 
-		efd = open(delta_filename, O_CREAT | O_EXCL | O_RDWR, 00600);
+		efd = open(delta_filename, O_CREAT | O_EXCL | O_WRONLY, 00644);
 		if (efd < 0) {
 			close(fd);
 			return -1;
@@ -668,7 +668,7 @@ int make_bsdiff_delta(char *old_filename, char *new_filename, char *delta_filena
 		memset(&small_header, 0, sizeof(struct header_v21));
 		memcpy(&small_header.magic, BSDIFF_HDR_FULLDL, 8);
 
-		efd = open(delta_filename, O_CREAT | O_EXCL | O_RDWR, 00600);
+		efd = open(delta_filename, O_CREAT | O_EXCL | O_WRONLY, 00644);
 		if (efd < 0) {
 			close(fd);
 			munmap(old_data, oldsize);
@@ -883,7 +883,7 @@ int make_bsdiff_delta(char *old_filename, char *new_filename, char *delta_filena
 
 	/* Create the patch file */
 
-	efd = open(delta_filename, O_CREAT | O_EXCL | O_RDWR, 00600);
+	efd = open(delta_filename, O_CREAT | O_EXCL | O_WRONLY, 00644);
 	if (efd < 0) {
 		ret = -1;
 		goto fulldl_free;

--- a/src/patch.c
+++ b/src/patch.c
@@ -690,7 +690,7 @@ static int apply_delta_v2(int subver, FILE *f,
 	cfclose(&ef);
 
 	/* Write the new file */
-	fd = open(new_filename, O_CREAT | O_EXCL | O_WRONLY, 0600);
+	fd = open(new_filename, O_CREAT | O_EXCL | O_WRONLY, 00644);
 	if (fd < 0) {
 		ret = -1;
 		goto writeerror;


### PR DESCRIPTION
Because the target files are only written to, not read from, by either
bsdiff or bspatch, we can open them write-only.

Also, I don't see a reason for the file permissions to be 600, so loosen
the permissions to be 644.

Signed-off-by: Patrick McCarty patrick.mccarty@intel.com
