### PR TITLE
Improve binary search performance time for diff creation

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -276,10 +276,20 @@ static int64_t search(int64_t *I, u_char *old, int64_t oldsize,
 	}
 
 	x = st + (en - st) / 2;
-	if (memcmp(old + I[x], new, MIN(oldsize - I[x], newsize)) < 0) {
+
+	int64_t length = MIN(oldsize - I[x], newsize);
+	int result = memcmp(old + I[x], new, length);
+
+	if (result < 0) {
 		return search(I, old, oldsize, new, newsize, x, en, pos);
-	} else {
+	} else if (result > 0) {
 		return search(I, old, oldsize, new, newsize, st, x, pos);
+	} else {
+		/* As a special case, short circuit for the first exact match
+		 * between old_data and new_data, since future exact matches
+		 * will have shorter length. */
+		*pos = I[en];
+		return length;
 	}
 }
 


### PR DESCRIPTION
When sections of old_data and new_data are found to be equal in the
course of searching for matches, short circuit at that point.